### PR TITLE
v1.7 Add the CodeBuild Environment Variable DS_DEPLOY_GITHUB_TOKEN_SECRETS_ID

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+#### PR description
+
+What is it for?
+
+#### Testing instructions
+
+-
+-
+
+#### JIRA ticket information
+
+Story: [DSOPS-000](https://jira.theglobeandmail.com/browse/DSOPS-000)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ module "codebuild_project" {
 | ecr\_name | \(Optional\) The name of the ECR repo. Required if var.deploy\_type is ecr or ecs | string | `"null"` | no |
 | logs\_retention\_in\_days | \(Optional\) Days to keep the cloudwatch logs for this codebuild project | number | `"14"` | no |
 | tags | \(Optional\) A mapping of tags to assign to the resource | map | `{}` | no |
-| central\_account\_github\_token\_aws\_secret\_arn | \(Required\) (Required) The repo access Github token AWS secret ARN in the ds-ml-shared-svcs-prod AWS account | string | n/a | yes |
+| central\_account\_github\_token\_aws\_secret\_arn | \(Required\) The repo access Github token AWS secret ARN in the ds-ml-shared-svcs-prod AWS account | string | n/a | yes |
 | central\_account\_github\_token\_aws\_kms\_cmk\_arn | \(Required\) The repo access Github token AWS KMS customer managed key ARN in the ds-ml-shared-svcs-prod AWS account | string | n/a | yes |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ module "codebuild_project" {
   deploy_type = var.deploy_type
   ecr_name    = var.ecr_name
   tags        = var.tags
-  central_account_github_token_aws_secret_arn = central-account-github-token-aws-secret-arn
-  central_account_github_token_aws_kms_cmk_arn = central-account-github-token-aws-kms-cmk-arn
+  central_account_github_token_aws_secret_arn = var.central_account_github_token_aws_secret_arn
+  central_account_github_token_aws_kms_cmk_arn = var.central_account_github_token_aws_kms_cmk_arn
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ module "codebuild_project" {
   deploy_type = var.deploy_type
   ecr_name    = var.ecr_name
   tags        = var.tags
-  central_account_github_token_aws_secret_arn = var.central_account_github_token_aws_secret_arn
-  central_account_github_token_aws_kms_cmk_arn = var.central_account_github_token_aws_kms_cmk_arn
+  central_account_github_token_aws_secret_arn = central-account-github-token-aws-secret-arn
+  central_account_github_token_aws_kms_cmk_arn = central-account-github-token-aws-kms-cmk-arn
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ Creates a codebuild project and S3 artifact bucket to be used with codepipeline.
 
 ```hcl
 module "codebuild_project" {
-  source = "github.com/globeandmail/aws-codebuild-project?ref=1.4"
+  source = "github.com/globeandmail/aws-codebuild-project?ref=1.7"
 
   name        = var.name
   deploy_type = var.deploy_type
   ecr_name    = var.ecr_name
   tags        = var.tags
+  central_account_github_token_aws_secret_arn = var.central_account_github_token_aws_secret_arn
+  central_account_github_token_aws_kms_cmk_arn = var.central_account_github_token_aws_kms_cmk_arn
 }
 ```
 
@@ -28,8 +30,8 @@ module "codebuild_project" {
 | ecr\_name | \(Optional\) The name of the ECR repo. Required if var.deploy\_type is ecr or ecs | string | `"null"` | no |
 | logs\_retention\_in\_days | \(Optional\) Days to keep the cloudwatch logs for this codebuild project | number | `"14"` | no |
 | tags | \(Optional\) A mapping of tags to assign to the resource | map | `{}` | no |
-| cross\_account\_github\_token\_aws\_secret\_arn | \(Required\) (Required) The repo access Github token AWS secret ARN in the ds-ml-shared-svcs-prod AWS account | string | n/a | yes |
-| cross\_account\_github\_token\_aws\_kms\_cmk\_arn | \(Required\) The repo access Github token AWS KMS customer managed key ARN in the ds-ml-shared-svcs-prod AWS account | string | n/a | yes |
+| central\_account\_github\_token\_aws\_secret\_arn | \(Required\) (Required) The repo access Github token AWS secret ARN in the ds-ml-shared-svcs-prod AWS account | string | n/a | yes |
+| central\_account\_github\_token\_aws\_kms\_cmk\_arn | \(Required\) The repo access Github token AWS KMS customer managed key ARN in the ds-ml-shared-svcs-prod AWS account | string | n/a | yes |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ module "codebuild_project" {
 | ecr\_name | \(Optional\) The name of the ECR repo. Required if var.deploy\_type is ecr or ecs | string | `"null"` | no |
 | logs\_retention\_in\_days | \(Optional\) Days to keep the cloudwatch logs for this codebuild project | number | `"14"` | no |
 | tags | \(Optional\) A mapping of tags to assign to the resource | map | `{}` | no |
+| cross\_account\_github\_token\_aws\_secret\_arn | \(Required\) (Required) The repo access Github token AWS secret ARN in the ds-ml-shared-svcs-prod AWS account | string | n/a | yes |
+| cross\_account\_github\_token\_aws\_kms\_cmk\_arn | \(Required\) The repo access Github token AWS KMS customer managed key ARN in the ds-ml-shared-svcs-prod AWS account | string | n/a | yes |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ module "codebuild_project" {
 | ecr\_name | \(Optional\) The name of the ECR repo. Required if var.deploy\_type is ecr or ecs | string | `"null"` | no |
 | logs\_retention\_in\_days | \(Optional\) Days to keep the cloudwatch logs for this codebuild project | number | `"14"` | no |
 | tags | \(Optional\) A mapping of tags to assign to the resource | map | `{}` | no |
-| central\_account\_github\_token\_aws\_secret\_arn | \(Required\) The repo access Github token AWS secret ARN in the ds-ml-shared-svcs-prod AWS account | string | n/a | yes |
-| central\_account\_github\_token\_aws\_kms\_cmk\_arn | \(Required\) The repo access Github token AWS KMS customer managed key ARN in the ds-ml-shared-svcs-prod AWS account | string | n/a | yes |
+| central\_account\_github\_token\_aws\_secret\_arn | \(Required\) The repo access Github token AWS secret ARN in the central AWS account | string | n/a | yes |
+| central\_account\_github\_token\_aws\_kms\_cmk\_arn | \(Required\) The repo access Github token AWS KMS customer managed key ARN in the central AWS account | string | n/a | yes |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -135,7 +135,7 @@ data "aws_iam_policy_document" "codebuild_secrets_manager" {
       "secretsmanager:GetSecretValue"
     ]
     resources = [
-      replace(var.cross_account_github_token_aws_secret_arn, "/-.{6}$/", "-??????")
+      replace(var.central_account_github_token_aws_secret_arn, "/-.{6}$/", "-??????")
     ]
   }
 
@@ -144,7 +144,7 @@ data "aws_iam_policy_document" "codebuild_secrets_manager" {
       "kms:Decrypt"
     ]
     resources = [
-      var.cross_account_github_token_aws_kms_cmk_arn
+      var.central_account_github_token_aws_kms_cmk_arn
     ]
   }
 }
@@ -198,7 +198,7 @@ resource "aws_codebuild_project" "project" {
 
     environment_variable {
       name  = "REPO_ACCESS_GITHUB_TOKEN_SECRETS_ID"
-      value = var.cross_account_github_token_aws_secret_arn
+      value = var.central_account_github_token_aws_secret_arn
       type = "SECRETS_MANAGER"
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -197,7 +197,7 @@ resource "aws_codebuild_project" "project" {
     }
 
     environment_variable {
-      name  = "DS_DEPLOY_GITHUB_TOKEN"
+      name  = "DS_DEPLOY_GITHUB_TOKEN_SECRETS_ID"
       value = var.cross_account_github_token_aws_secret_arn
       type = "SECRETS_MANAGER"
     }

--- a/main.tf
+++ b/main.tf
@@ -197,7 +197,7 @@ resource "aws_codebuild_project" "project" {
     }
 
     environment_variable {
-      name  = "DS_DEPLOY_GITHUB_TOKEN_SECRETS_ID"
+      name  = "REPO_ACCESS_GITHUB_TOKEN_SECRETS_ID"
       value = var.cross_account_github_token_aws_secret_arn
       type = "SECRETS_MANAGER"
     }

--- a/variables.tf
+++ b/variables.tf
@@ -63,12 +63,10 @@ variable "tags" {
 
 variable "cross_account_github_token_aws_secret_arn" {
   type = string
-  description = "Github token AWS secret ARN in the ds-ml-shared-svcs-prod AWS account"
-  default = "arn:aws:secretsmanager:us-east-1:662847230022:secret:ds-ml-shared-svcs-prod/ds_deploy_github_token-wFuICP"
+  description = "(Required) The repo access Github token AWS secret ARN in the ds-ml-shared-svcs-prod AWS account"
 }
 
 variable "cross_account_github_token_aws_kms_cmk_arn" {
   type = string
-  description = "Github token AWS KMS customer managed key ARN in the ds-ml-shared-svcs-prod AWS account"
-  default = "arn:aws:kms:us-east-1:662847230022:key/c17f9e9c-2541-4855-893e-e6eed203d101"
+  description = "(Required) The repo access Github token AWS KMS customer managed key ARN in the ds-ml-shared-svcs-prod AWS account"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -63,10 +63,10 @@ variable "tags" {
 
 variable "central_account_github_token_aws_secret_arn" {
   type = string
-  description = "(Required) The repo access Github token AWS secret ARN in the ds-ml-shared-svcs-prod AWS account"
+  description = "(Required) The repo access Github token AWS secret ARN in the central AWS account"
 }
 
 variable "central_account_github_token_aws_kms_cmk_arn" {
   type = string
-  description = "(Required) The repo access Github token AWS KMS customer managed key ARN in the ds-ml-shared-svcs-prod AWS account"
+  description = "(Required) The repo access Github token AWS KMS customer managed key ARN in the central AWS account"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -60,3 +60,15 @@ variable "tags" {
   description = "(Optional) A mapping of tags to assign to the resource"
   default     = {}
 }
+
+varaible "cross_account_github_token_aws_secret_arn" {
+  type = string
+  description = "Github token AWS secret ARN in the ds-ml-shared-svcs-prod AWS account"
+  default = "arn:aws:secretsmanager:us-east-1:662847230022:secret:ds-ml-shared-svcs-prod/ds_deploy_github_token-wFuICP"
+}
+
+varaible "cross_account_github_token_aws_kms_cmk_arn" {
+  type = string
+  description = "Github token AWS KMS customer managed key ARN in the ds-ml-shared-svcs-prod AWS account"
+  default = "arn:aws:kms:us-east-1:662847230022:key/c17f9e9c-2541-4855-893e-e6eed203d101"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -61,12 +61,12 @@ variable "tags" {
   default     = {}
 }
 
-variable "cross_account_github_token_aws_secret_arn" {
+variable "central_account_github_token_aws_secret_arn" {
   type = string
   description = "(Required) The repo access Github token AWS secret ARN in the ds-ml-shared-svcs-prod AWS account"
 }
 
-variable "cross_account_github_token_aws_kms_cmk_arn" {
+variable "central_account_github_token_aws_kms_cmk_arn" {
   type = string
   description = "(Required) The repo access Github token AWS KMS customer managed key ARN in the ds-ml-shared-svcs-prod AWS account"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -61,13 +61,13 @@ variable "tags" {
   default     = {}
 }
 
-varaible "cross_account_github_token_aws_secret_arn" {
+variable "cross_account_github_token_aws_secret_arn" {
   type = string
   description = "Github token AWS secret ARN in the ds-ml-shared-svcs-prod AWS account"
   default = "arn:aws:secretsmanager:us-east-1:662847230022:secret:ds-ml-shared-svcs-prod/ds_deploy_github_token-wFuICP"
 }
 
-varaible "cross_account_github_token_aws_kms_cmk_arn" {
+variable "cross_account_github_token_aws_kms_cmk_arn" {
   type = string
   description = "Github token AWS KMS customer managed key ARN in the ds-ml-shared-svcs-prod AWS account"
   default = "arn:aws:kms:us-east-1:662847230022:key/c17f9e9c-2541-4855-893e-e6eed203d101"


### PR DESCRIPTION
#### PR description

What is it for?
The PR is to add the Code Build secrets-manager environment variable DS_DEPLOY_GITHUB_TOKEN_SECRETS_ID.
Also to give the CodeBuild IAM role permission to read the KMS key and Github token secrets in the ds-ml-shared-svcs-prod AWS account.

#### Testing instructions

- Verify in any Sophi Pop CodeBuild project that the IAM role has access to the KMS key and Secret. 
- Modify the buildspec.yml file in any Sophi pop code repository following the sample [here](https://github.com/globeandmail/sophi-pop-iceberg-query/blob/DSOPS-81/buildspec.yml).
- Verify a successful run in the Sophi Pop CodeBuild project.

#### JIRA ticket information

Story: [DSOPS-81](https://jira.theglobeandmail.com/browse/DSOPS-81)