### PR TITLE
AHP-917 Change use_repo_access_github_token to optional variable and add optional variable s3_block_public_access

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Creates a codebuild project and S3 artifact bucket to be used with codepipeline.
 
 ```hcl
 module "codebuild_project" {
-  source = "github.com/globeandmail/aws-codebuild-project?ref=1.7"
+  source = "github.com/globeandmail/aws-codebuild-project?ref=1.8"
 
   name        = var.name
   deploy_type = var.deploy_type
   ecr_name    = var.ecr_name
   tags        = var.tags
-  central_account_github_token_aws_secret_arn = var.central_account_github_token_aws_secret_arn
-  central_account_github_token_aws_kms_cmk_arn = var.central_account_github_token_aws_kms_cmk_arn
+  svcs_account_github_token_aws_secret_arn = var.svcs_account_github_token_aws_secret_arn
+  svcs_account_github_token_aws_kms_cmk_arn = var.svcs_account_github_token_aws_kms_cmk_arn
 }
 ```
 
@@ -30,8 +30,10 @@ module "codebuild_project" {
 | ecr\_name | \(Optional\) The name of the ECR repo. Required if var.deploy\_type is ecr or ecs | string | `"null"` | no |
 | logs\_retention\_in\_days | \(Optional\) Days to keep the cloudwatch logs for this codebuild project | number | `"14"` | no |
 | tags | \(Optional\) A mapping of tags to assign to the resource | map | `{}` | no |
-| central\_account\_github\_token\_aws\_secret\_arn | \(Required\) The repo access Github token AWS secret ARN in the central AWS account | string | n/a | yes |
-| central\_account\_github\_token\_aws\_kms\_cmk\_arn | \(Required\) The repo access Github token AWS KMS customer managed key ARN in the central AWS account | string | n/a | yes |
+| use\_repo\_access\_github\_token | \(Optional\) Allow the AWS codebuild IAM role read access to the REPO\_ACCESS\_GITHUB\_TOKEN secrets manager secret in the shared service account.<br>Defaults to false. | `bool` | `false` | no |
+| svcs\_account\_github\_token\_aws\_secret\_arn | \(Optional\) The AWS secret ARN for the repo access Github token.<br>The secret is created in the shared service account.<br>Required if var.use\_repo\_access\_github\_token is true. | `string` | `null` | no |
+| svcs\_account\_github\_token\_aws\_kms\_cmk\_arn | \(Optional\)  The us-east-1 region AWS KMS customer managed key ARN for encrypting the repo access Github token AWS secret.<br>The key is created in the shared service account.<br>Required if var.use\_repo\_access\_github\_token is true. | `string` | `null` | no |
+| s3\_block\_public\_access | \(Optional\) Enable the S3 block public access setting for the artifact bucket. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -61,12 +61,37 @@ variable "tags" {
   default     = {}
 }
 
-variable "central_account_github_token_aws_secret_arn" {
-  type = string
-  description = "(Required) The repo access Github token AWS secret ARN in the central AWS account"
+variable "use_repo_access_github_token" {
+  type        = bool
+  description = <<EOT
+                (Optional) Allow the AWS codebuild IAM role read access to the REPO_ACCESS_GITHUB_TOKEN secrets manager secret in the shared service account.
+                Defaults to false.
+                EOT
+  default     = false
 }
 
-variable "central_account_github_token_aws_kms_cmk_arn" {
-  type = string
-  description = "(Required) The repo access Github token AWS KMS customer managed key ARN in the central AWS account"
+variable "svcs_account_github_token_aws_secret_arn" {
+  type        = string
+  description = <<EOT
+                (Optional) The AWS secret ARN for the repo access Github token.
+                The secret is created in the shared service account.
+                Required if var.use_repo_access_github_token is true.
+                EOT
+  default     = null
+}
+
+variable "svcs_account_github_token_aws_kms_cmk_arn" {
+  type        = string
+  description = <<EOT
+                (Optional) The us-east-1 region AWS KMS customer managed key ARN for encrypting the repo access Github token AWS secret.
+                The key is created in the shared service account.
+                Required if var.use_repo_access_github_token is true.
+                EOT
+  default     = null
+}
+
+variable "s3_block_public_access" {
+  type = bool
+  description = "(Optional) Enable the S3 block public access setting for the artifact bucket."
+  default = false
 }


### PR DESCRIPTION
#### PR description

What is it for?
The PR is to address the failed security checks in AWS security hub.
 - add use_repo_access_github_token optional variable, default is false.
 - add aws_s3_bucket_public_access_block resource when var.s3_block_public_access = true (optional variable with default = false).
 
#### Testing instructions

- Verify in AWS security hub that the failed security check is fixed: S3.8 S3 Block Public Access setting should be enabled at the bucket-level.

#### JIRA ticket information

Story: [AHP-917](https://jira.theglobeandmail.com/browse/AHP-917)
