### PR TITLE
AHP-1113 Add optional variables use_sysdig_api_token and svcs_account_sysdig_api_token_aws_secret_arn

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,21 @@ Creates a codebuild project and S3 artifact bucket to be used with codepipeline.
 
 ```hcl
 module "codebuild_project" {
-  source = "github.com/globeandmail/aws-codebuild-project?ref=2.0"
+  source = "github.com/globeandmail/aws-codebuild-project?ref=2.1"
 
-  name        = var.name
-  deploy_type = var.deploy_type
-  ecr_name    = var.ecr_name
-  tags        = var.tags
-  svcs_account_github_token_aws_secret_arn = var.svcs_account_github_token_aws_secret_arn
-  svcs_account_aws_kms_cmk_arn = var.svcs_account_aws_kms_cmk_arn
+  name                                         = var.name
+  deploy_type                                  = var.deploy_type
+  ecr_name                                     = var.ecr_name
+  build_compute_type                           = var.build_compute_type
+  use_docker_credentials                       = var.use_docker_credentials
+  buildspec                                    = var.buildspec
+  tags                                         = var.tags
+  use_repo_access_github_token                 = var.use_repo_access_github_token
+  svcs_account_github_token_aws_secret_arn     = var.svcs_account_github_token_aws_secret_arn
+  svcs_account_aws_kms_cmk_arn                 = var.svcs_account_aws_kms_cmk_arn
+  s3_block_public_access                       = var.s3_block_public_access
+  use_sysdig_api_token                         = var.use_sysdig_api_token
+  svcs_account_sysdig_api_token_aws_secret_arn = var.svcs_account_sysdig_api_token_aws_secret_arn
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Creates a codebuild project and S3 artifact bucket to be used with codepipeline.
 
 ```hcl
 module "codebuild_project" {
-  source = "github.com/globeandmail/aws-codebuild-project?ref=1.8"
+  source = "github.com/globeandmail/aws-codebuild-project?ref=2.0"
 
   name        = var.name
   deploy_type = var.deploy_type
   ecr_name    = var.ecr_name
   tags        = var.tags
   svcs_account_github_token_aws_secret_arn = var.svcs_account_github_token_aws_secret_arn
-  svcs_account_github_token_aws_kms_cmk_arn = var.svcs_account_github_token_aws_kms_cmk_arn
+  svcs_account_aws_kms_cmk_arn = var.svcs_account_aws_kms_cmk_arn
 }
 ```
 
@@ -32,8 +32,10 @@ module "codebuild_project" {
 | tags | \(Optional\) A mapping of tags to assign to the resource | map | `{}` | no |
 | use\_repo\_access\_github\_token | \(Optional\) Allow the AWS codebuild IAM role read access to the REPO\_ACCESS\_GITHUB\_TOKEN secrets manager secret in the shared service account.<br>Defaults to false. | `bool` | `false` | no |
 | svcs\_account\_github\_token\_aws\_secret\_arn | \(Optional\) The AWS secret ARN for the repo access Github token.<br>The secret is created in the shared service account.<br>Required if var.use\_repo\_access\_github\_token is true. | `string` | `null` | no |
-| svcs\_account\_github\_token\_aws\_kms\_cmk\_arn | \(Optional\)  The us-east-1 region AWS KMS customer managed key ARN for encrypting the repo access Github token AWS secret.<br>The key is created in the shared service account.<br>Required if var.use\_repo\_access\_github\_token is true. | `string` | `null` | no |
+| svcs\_account\_aws\_kms\_cmk\_arn | \(Optional\)  The us-east-1 region AWS KMS customer managed key ARN for encrypting all AWS secrets.<br>The key is created in the shared service account.<br>Required if var.use\_repo\_access\_github\_token or var.use\_sysdig\_api\_token is true. | `string` | `null` | no |
 | s3\_block\_public\_access | \(Optional\) Enable the S3 block public access setting for the artifact bucket. | `bool` | `false` | no |
+| use\_sysdig\_api\_token | \(Optional\) Allow the AWS codebuild IAM role read access to the SYSDIG\_API\_TOKEN secrets manager secret in the shared service account.<br>Defaults to false. | `bool` | `false` | no |
+| svcs\_account\_sysdig\_api\_token\_aws\_secret\_arn | \(Optional\) The AWS secret ARN for the sysdig API token.<br>The secret is created in the shared service account.<br>Required if var.use\_sysdig\_api\_token is true. | `string` | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -141,13 +141,14 @@ resource "aws_iam_role_policy" "codebuild_ecr" {
 }
 
 data "aws_iam_policy_document" "codebuild_secrets_manager" {
-  count = var.use_repo_access_github_token ? 1 : 0
+  count = var.use_repo_access_github_token || var.use_sysdig_api_token ? 1 : 0
   statement {
     actions = [
       "secretsmanager:GetSecretValue"
     ]
     resources = [
-      replace(var.svcs_account_github_token_aws_secret_arn, "/-.{6}$/", "-??????")
+      replace(var.svcs_account_github_token_aws_secret_arn, "/-.{6}$/", "-??????"),
+      replace(var.svcs_account_sysdig_api_token_aws_secret_arn, "/-.{6}$/", "-??????")
     ]
   }
 
@@ -156,13 +157,13 @@ data "aws_iam_policy_document" "codebuild_secrets_manager" {
       "kms:Decrypt"
     ]
     resources = [
-      var.svcs_account_github_token_aws_kms_cmk_arn
+      var.svcs_account_aws_kms_cmk_arn
     ]
   }
 }
 
 resource "aws_iam_role_policy" "codebuild_secrets_manager" {
-  count  = var.use_repo_access_github_token ? 1 : 0
+  count  = var.use_repo_access_github_token || var.use_sysdig_api_token ? 1 : 0
   name   = "codebuild-secrets-manager-${var.name}"
   role   = aws_iam_role.codebuild.id
   policy = data.aws_iam_policy_document.codebuild_secrets_manager[0].json
@@ -214,6 +215,15 @@ resource "aws_codebuild_project" "project" {
       content {
         name  = "REPO_ACCESS_GITHUB_TOKEN_SECRETS_ID"
         value = var.svcs_account_github_token_aws_secret_arn
+        type = "SECRETS_MANAGER"
+      }
+    }
+
+    dynamic "environment_variable" {
+      for_each = var.use_sysdig_api_token ? [1] : []
+      content {
+        name  = "SYSDIG_API_TOKEN"
+        value = var.svcs_account_sysdig_api_token_aws_secret_arn
         type = "SECRETS_MANAGER"
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -142,14 +142,28 @@ resource "aws_iam_role_policy" "codebuild_ecr" {
 
 data "aws_iam_policy_document" "codebuild_secrets_manager" {
   count = var.use_repo_access_github_token || var.use_sysdig_api_token ? 1 : 0
-  statement {
-    actions = [
-      "secretsmanager:GetSecretValue"
-    ]
-    resources = [
-      replace(var.svcs_account_github_token_aws_secret_arn, "/-.{6}$/", "-??????"),
-      replace(var.svcs_account_sysdig_api_token_aws_secret_arn, "/-.{6}$/", "-??????")
-    ]
+  dynamic "statement" {
+    for_each = var.use_repo_access_github_token == true ? [1] : []
+    content {
+      actions = [
+        "secretsmanager:GetSecretValue"
+      ]
+      resources = [
+        replace(var.svcs_account_github_token_aws_secret_arn, "/-.{6}$/", "-??????")
+      ]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.use_sysdig_api_token == true ? [1] : []
+    content {
+      actions = [
+        "secretsmanager:GetSecretValue"
+      ]
+      resources = [
+        replace(var.svcs_account_sysdig_api_token_aws_secret_arn, "/-.{6}$/", "-??????")
+      ]
+    }
   }
 
   statement {

--- a/main.tf
+++ b/main.tf
@@ -222,7 +222,7 @@ resource "aws_codebuild_project" "project" {
     dynamic "environment_variable" {
       for_each = var.use_sysdig_api_token ? [1] : []
       content {
-        name  = "SYSDIG_API_TOKEN"
+        name  = "SYSDIG_API_TOKEN_SECRETS_ID"
         value = var.svcs_account_sysdig_api_token_aws_secret_arn
         type = "SECRETS_MANAGER"
       }

--- a/variables.tf
+++ b/variables.tf
@@ -80,12 +80,12 @@ variable "svcs_account_github_token_aws_secret_arn" {
   default     = null
 }
 
-variable "svcs_account_github_token_aws_kms_cmk_arn" {
+variable "svcs_account_aws_kms_cmk_arn" {
   type        = string
   description = <<EOT
-                (Optional) The us-east-1 region AWS KMS customer managed key ARN for encrypting the repo access Github token AWS secret.
+                (Optional) The us-east-1 region AWS KMS customer managed key ARN for encrypting all AWS secrets.
                 The key is created in the shared service account.
-                Required if var.use_repo_access_github_token is true.
+                Required if var.use_repo_access_github_token or var.use_sysdig_api_token is true.
                 EOT
   default     = null
 }
@@ -94,4 +94,23 @@ variable "s3_block_public_access" {
   type = bool
   description = "(Optional) Enable the S3 block public access setting for the artifact bucket."
   default = false
+}
+
+variable "use_sysdig_api_token" {
+  type        = bool
+  description = <<EOT
+                (Optional) Allow the AWS codebuild IAM role read access to the SYSDIG_API_TOKEN secrets manager secret in the shared service account.
+                Defaults to false.
+                EOT
+  default     = false
+}
+
+variable "svcs_account_sysdig_api_token_aws_secret_arn" {
+  type        = string
+  description = <<EOT
+                (Optional) The AWS secret ARN for the sysdig API token.
+                The secret is created in the shared service account.
+                Required if var.use_sysdig_api_token is true.
+                EOT
+  default     = null
 }


### PR DESCRIPTION
#### PR description

What is it for?
The PR is to add the optional variables `use_sysdig_api_token` and `svcs_account_sysdig_api_token_aws_secret_arn`. 
The AWS secret is in the ds-ml-shared-svcs-prod AWS account.
The API token is for Sysdig image scanning.

#### Testing instructions

- Verify that the variables are optional and the AWS secret is readable from other Globe and Mail AWS accounts.

#### JIRA ticket information

Story: [DSOPS-428](https://jira.theglobeandmail.com/browse/DSOPS-428)
[AHP-1113](https://jira.theglobeandmail.com/browse/AHP-1113)