### PR TITLE
some use cases require CodeBuild IAM role ARN, exposing it

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -198,6 +198,19 @@ resource "aws_codebuild_project" "project" {
       }
     }
 
+    environment_variable {
+      name    = "AWS_ACCOUNT_ID"
+      value   = local.account_id
+    }
+
+    dynamic "environment_variable" {
+      for_each = var.ecr_image_tag == null ? [] : [var.env_repo_name]
+      content {
+        name  = "IMAGE_TAG"
+        value = var.ecr_image_tag
+      }
+    }
+
     dynamic "environment_variable" {
       for_each = var.use_docker_credentials == true ? [1] : []
       content {

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,7 @@ output "artifact_bucket_arn" {
 output "code_build_iam_role_name" {
   value = aws_iam_role.codebuild.id
 }
+
+output "code_build_iam_role_arn" {
+  value = aws_iam_role.codebuild.arn
+}

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,12 @@ variable "ecr_name" {
   default     = null
 }
 
+variable "ecr_image_tag" {
+  type        = string
+  description = "The tag of the ECR image. Required if var.deploy_type is ecr or ecs"
+  default     = "latest"
+}
+
 variable "codebuild_image" {
   type        = string
   description = "(Optional) The codebuild image to use"


### PR DESCRIPTION
#### PR description

some use cases require CodeBuild IAM role ARN, exposing it

#### Testing instructions

Use like this:
```
 module "codebuild_project" {
  source = "github.com/globeandmail/aws-codebuild-project?ref=expose_role_ARN"
...
```